### PR TITLE
Fixed compilation errors for dynamics2d_epuck_model.cpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,8 +37,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/ARGoSPackaging.cmake)
 
 
 # Set up ARGoS compilation information
-include_directories(${CMAKE_SOURCE_DIR} ${ARGOS_INCLUDE_DIRS})
-link_directories(${ARGOS_LIBRARY_DIRS})
+include_directories(BEFORE ${CMAKE_SOURCE_DIR})
 
 #
 # Compile stuff


### PR DESCRIPTION
Changed ordering of include directories to fix #4.

These compilation errors occur because `ARGoSBuildChecks.cmake` adds`${ARGOS_INCLUDE_DIRS}` to the list of include directories _before_ `${CMAKE_SOURCE_DIR}`. This causes `make` to compile `dynamics2d_epuck_model.cpp` against the default ARGoS `epuck_entity.h`, instead of the one from argos3-epuck. Adding `${CMAKE_SOURCE_DIR}` to the front of the list ensures that the argos3-epuck plugin code takes precedence over the ARGoS installation it is being compiled against. Thanks to @richard-redpath for spotting this.

Also removed duplicate inclusions of `${ARGOS_INCLUDE_DIRS}` and `${ARGOS_LIBRARY_DIRS}`, which are already added by `ARGoSBuildChecks.cmake`.