### PR TITLE
Modified epuck_rab_equipped_entity.cpp to include Add/Remove Space operations

### DIFF
--- a/src/plugins/robots/e-puck/simulator/epuck_rab_equipped_entity.cpp
+++ b/src/plugins/robots/e-puck/simulator/epuck_rab_equipped_entity.cpp
@@ -238,7 +238,31 @@ void CEpuckRABEquippedEntitySpaceHashUpdater::operator()(CAbstractSpaceHash<CEpu
 /****************************************/
 /****************************************/
 
-REGISTER_STANDARD_SPACE_OPERATIONS_ON_ENTITY(CEpuckRABEquippedEntity);
+class CSpaceOperationAddCEpuckRABEquippedEntity : public CSpaceOperationAddEntity {
+public:
+    void ApplyTo(CSpace& c_space, CEpuckRABEquippedEntity& c_entity) {
+        /* Add entity to space - this ensures that the RAB entity
+         * gets an id before being added to the RAB medium */
+        c_space.AddEntity(c_entity);
+        /* Enable the RAB entity, if it's enabled - this ensures that
+         * the entity gets added to the RAB if it's enabled */
+        c_entity.SetEnabled(c_entity.IsEnabled());
+    }
+};
+
+class CSpaceOperationRemoveCEpuckRABEquippedEntity : public CSpaceOperationRemoveEntity {
+public:
+    void ApplyTo(CSpace& c_space, CEpuckRABEquippedEntity& c_entity) {
+        /* Disable the entity - this ensures that the entity is
+         * removed from the RAB medium */
+        c_entity.Disable();
+        /* Remove the RAB entity from space */
+        c_space.RemoveEntity(c_entity);
+    }
+};
+
+REGISTER_SPACE_OPERATION(CSpaceOperationAddEntity, CSpaceOperationAddCEpuckRABEquippedEntity, CEpuckRABEquippedEntity);
+REGISTER_SPACE_OPERATION(CSpaceOperationRemoveEntity, CSpaceOperationRemoveCEpuckRABEquippedEntity, CEpuckRABEquippedEntity);
 
 /****************************************/
 /****************************************/


### PR DESCRIPTION
Modified `epuck_rab_equipped_entity.cpp` to include Add/Remove Space operations, to match changes made to `rab_equipped_entity.cpp` in https://github.com/ilpincy/argos3/commit/eb29f4127961fc698302947b76f35a49a1d629e4

This finishes off the changes I made in https://github.com/lgarattoni/argos3-epuck/pull/7 that have already been merged. Although the current master branch compiles successfully against the latest version of ARGoS, run-time errors like the following will occur without these new changes:

`[FATAL] RAB entity "epuck1.rab_0" is not managed by the RAB medium "rab"`

Closes https://github.com/lgarattoni/argos3-epuck/issues/5