### PR TITLE
Support the latest ARGoS version beta59

### DIFF
--- a/src/cmake/ARGoSBuildChecks.cmake
+++ b/src/cmake/ARGoSBuildChecks.cmake
@@ -3,10 +3,11 @@
 #
 if(ARGOS_BUILD_FOR_SIMULATOR)
   find_package(PkgConfig)
-  pkg_check_modules(ARGOS REQUIRED argos3_simulator)
+  find_package(ARGoS REQUIRED)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ARGOS_PREFIX}/share/argos3/cmake)
-  include_directories(${ARGOS_INCLUDE_DIRS})
-  link_directories(${ARGOS_LIBRARY_DIRS})
+  include_directories(${CMAKE_SOURCE_DIR} ${ARGOS_INCLUDE_DIRS})
+  link_directories(${ARGOS_LIBRARY_DIR})
+  link_libraries(${ARGOS_LDFLAGS})
 elseif(ARGOS_BUILD_FOR_LOCALEPUCK)
   find_package(PkgConfig)
   pkg_check_modules(ARGOS REQUIRED argos3_localepuck)
@@ -32,7 +33,7 @@ endif (NOT ARGOS_BUILD_FOR_EPUCK)
 # Check for Qt and OpenGL when compiling for the simulator
 #
 if(ARGOS_BUILD_FOR_SIMULATOR)
-  include(ARGoSCheckQTOpenGL)
+  include(FindARGoSQTOpenGL)
 endif(ARGOS_BUILD_FOR_SIMULATOR)
 
 #

--- a/src/plugins/robots/e-puck/SimLibrary.cmake
+++ b/src/plugins/robots/e-puck/SimLibrary.cmake
@@ -21,11 +21,11 @@ set(ARGOS3_HEADERS_PLUGINS_ROBOTS_EPUCK_SIMULATOR
   simulator/epuck_ircom_default_sensor.h
   simulator/epuck_ground_rotzonly_sensor.h
   simulator/epuck_rab_equipped_entity.h)
-if(ARGOS_COMPILE_QTOPENGL)
+if(ARGOS_QTOPENGL_FOUND)
   set(ARGOS3_HEADERS_PLUGINS_ROBOTS_EPUCK_SIMULATOR
     ${ARGOS3_HEADERS_PLUGINS_ROBOTS_EPUCK_SIMULATOR}
     simulator/qtopengl_epuck.h)
-endif(ARGOS_COMPILE_QTOPENGL)
+endif(ARGOS_QTOPENGL_FOUND)
 
 # Install location for the e-puck simulator headers
 install(
@@ -54,11 +54,11 @@ set(ARGOS3_SOURCES_PLUGINS_ROBOTS_EPUCK
   simulator/epuck_ircom_default_sensor.cpp
   simulator/epuck_ground_rotzonly_sensor.cpp
   simulator/epuck_rab_equipped_entity.cpp)
-if(ARGOS_COMPILE_QTOPENGL)
+if(ARGOS_QTOPENGL_FOUND)
   set(ARGOS3_SOURCES_PLUGINS_ROBOTS_EPUCK
     ${ARGOS3_SOURCES_PLUGINS_ROBOTS_EPUCK}
     simulator/qtopengl_epuck.cpp)
-endif(ARGOS_COMPILE_QTOPENGL)
+endif(ARGOS_QTOPENGL_FOUND)
 
 #
 # Create e-puck plugin
@@ -71,10 +71,10 @@ target_link_libraries(argos3plugin_${ARGOS_BUILD_FOR}_epuck
   argos3core_${ARGOS_BUILD_FOR}
   argos3plugin_${ARGOS_BUILD_FOR}_genericrobot
   argos3plugin_${ARGOS_BUILD_FOR}_dynamics2d)
-if(ARGOS_COMPILE_QTOPENGL)
+if(ARGOS_QTOPENGL_FOUND)
   target_link_libraries(argos3plugin_${ARGOS_BUILD_FOR}_epuck
     argos3plugin_${ARGOS_BUILD_FOR}_qtopengl)
-endif(ARGOS_COMPILE_QTOPENGL)
+endif(ARGOS_QTOPENGL_FOUND)
 
 # Install location for the e-puck plugin
 install(TARGETS argos3plugin_${ARGOS_BUILD_FOR}_epuck


### PR DESCRIPTION
Currently, the epuck plugin is not compatible with the latest ARGoS version beta59 (see https://github.com/ilpincy/argos3/issues/178). This pull request fixes the issue.